### PR TITLE
Add TS password manager extension

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -1,0 +1,53 @@
+// background/index.ts
+import {deriveKey, encrypt, decrypt} from "~utils/crypto"
+import {getEntries, updateEntry} from "~utils/storage"
+
+let sessionKey: CryptoKey | null = null
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  ;(async () => {
+    switch (msg.cmd) {
+      case "login": {
+        sessionKey = await deriveKey(msg.master)
+        sendResponse({ ok: true })
+        break
+      }
+      case "logout": {
+        sessionKey = null
+        sendResponse({ ok: true })
+        break
+      }
+      case "get-credentials": {
+        if (!sessionKey) {
+          sendResponse({})
+          break
+        }
+        const entries = await getEntries()
+        const entry = entries[msg.host]
+        if (entry) {
+          const pass = await decrypt(entry.data, sessionKey)
+          sendResponse({ user: entry.user, pass })
+        } else {
+          sendResponse({})
+        }
+        break
+      }
+      case "save-credentials": {
+        if (!sessionKey) {
+          sendResponse({ ok: false })
+          break
+        }
+        const data = await encrypt(msg.pass, sessionKey)
+        await updateEntry(msg.host, { user: msg.user, data })
+        sendResponse({ ok: true })
+        break
+      }
+      case "list": {
+        const entries = await getEntries()
+        sendResponse({ entries })
+        break
+      }
+    }
+  })()
+  return true
+})

--- a/options/Options.tsx
+++ b/options/Options.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react"
+
+export default function Options() {
+  const [host, setHost] = useState("")
+  const [user, setUser] = useState("")
+  const [pass, setPass] = useState("")
+
+  const save = () => {
+    chrome.runtime.sendMessage(
+      { cmd: "save-credentials", host, user, pass },
+      () => {
+        setHost("")
+        setUser("")
+        setPass("")
+      }
+    )
+  }
+
+  const gen = () => {
+    const arr = crypto.getRandomValues(new Uint8Array(16))
+    setPass(btoa(String.fromCharCode(...arr)))
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Add Credential</h2>
+      <input
+        placeholder="host"
+        value={host}
+        onChange={(e) => setHost(e.target.value)}
+      />
+      <input
+        placeholder="user"
+        value={user}
+        onChange={(e) => setUser(e.target.value)}
+      />
+      <input
+        placeholder="password"
+        value={pass}
+        onChange={(e) => setPass(e.target.value)}
+      />
+      <button onClick={gen}>Generate</button>
+      <button onClick={save}>Save</button>
+    </div>
+  )
+}
+

--- a/popup/DomainTree.tsx
+++ b/popup/DomainTree.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react"
+import type { StoredEntry } from "~utils/storage"
+
+interface Props {
+  entries: Record<string, StoredEntry>
+}
+
+const group = (entries: Record<string, StoredEntry>) => {
+  const res: Record<string, Record<string, StoredEntry>> = {}
+  for (const [host, e] of Object.entries(entries)) {
+    const parts = host.split(".")
+    const base = parts.slice(-2).join(".")
+    const sub = parts.length > 2 ? parts.slice(0, -2).join(".") : ""
+    if (!res[base]) res[base] = {}
+    res[base][sub] = e
+  }
+  return res
+}
+
+export default function DomainTree({ entries }: Props) {
+  const [open, setOpen] = useState<Record<string, boolean>>({})
+  const groups = group(entries)
+
+  return (
+    <div>
+      {Object.entries(groups).map(([base, subs]) => (
+        <div key={base}>
+          <div
+            style={{ cursor: "pointer", fontWeight: "bold" }}
+            onClick={() => setOpen({ ...open, [base]: !open[base] })}
+          >
+            {base}
+          </div>
+          {open[base] && (
+            <div style={{ marginLeft: 12 }}>
+              {Object.entries(subs).map(([sub, e]) => (
+                <div key={sub}>{sub ? `${sub} - ${e.user}` : e.user}</div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+

--- a/popup/Popup.tsx
+++ b/popup/Popup.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react"
+import DomainTree from "./DomainTree"
+
+export default function Popup() {
+  const [master, setMaster] = useState("")
+  const [logged, setLogged] = useState(false)
+  const [entries, setEntries] = useState({})
+
+  useEffect(() => {
+    if (logged) {
+      chrome.runtime.sendMessage({ cmd: "list" }, (res) => {
+        if (res?.entries) setEntries(res.entries)
+      })
+    }
+  }, [logged])
+
+  const login = () => {
+    chrome.runtime.sendMessage({ cmd: "login", master }, (res) => {
+      if (res?.ok) setLogged(true)
+    })
+  }
+
+  const logout = () => {
+    chrome.runtime.sendMessage({ cmd: "logout" }, () => setLogged(false))
+  }
+
+  return logged ? (
+    <div style={{ minWidth: 200 }}>
+      <button onClick={logout}>Logout</button>
+      <DomainTree entries={entries} />
+    </div>
+  ) : (
+    <div style={{ minWidth: 200 }}>
+      <input
+        type="password"
+        placeholder="Master password"
+        value={master}
+        onChange={(e) => setMaster(e.target.value)}
+      />
+      <button onClick={login}>Login</button>
+    </div>
+  )
+}
+

--- a/utils/crypto.ts
+++ b/utils/crypto.ts
@@ -1,14 +1,16 @@
 // utils/crypto.ts
-import {argon2id} from "argon2-browser"
+// derive key using PBKDF2 to avoid external dependencies
 
 export async function deriveKey(master: string) {
-  const {hash} = await argon2id({
-    pass: master,
-    salt: await crypto.getRandomValues(new Uint8Array(16)),
-    time: 3, mem: 2**16, hashLen: 32, parallelism: 1
-  })
-  return crypto.subtle.importKey(
-    "raw", hash, "AES-GCM", false, ["encrypt", "decrypt"]
+  const enc = new TextEncoder().encode(master)
+  const salt = crypto.getRandomValues(new Uint8Array(16))
+  const baseKey = await crypto.subtle.importKey("raw", enc, "PBKDF2", false, ["deriveKey"])
+  return crypto.subtle.deriveKey(
+    { name: "PBKDF2", salt, iterations: 100000, hash: "SHA-256" },
+    baseKey,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
   )
 }
 
@@ -17,4 +19,11 @@ export async function encrypt(data: string, key: CryptoKey) {
   const enc = new TextEncoder().encode(data)
   const buf = await crypto.subtle.encrypt({name:"AES-GCM", iv}, key, enc)
   return {iv: Array.from(iv), buf: Array.from(new Uint8Array(buf))}
+}
+
+export async function decrypt(enc: {iv: number[], buf: number[]}, key: CryptoKey) {
+  const iv = new Uint8Array(enc.iv)
+  const buf = new Uint8Array(enc.buf)
+  const dec = await crypto.subtle.decrypt({name:"AES-GCM", iv}, key, buf)
+  return new TextDecoder().decode(dec)
 }

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,0 +1,28 @@
+// utils/storage.ts
+
+export interface Encrypted {
+  iv: number[]
+  buf: number[]
+}
+
+export interface StoredEntry {
+  user: string
+  data: Encrypted
+}
+
+const KEY = "pm-data"
+
+export async function getEntries(): Promise<Record<string, StoredEntry>> {
+  const res = await chrome.storage.local.get(KEY)
+  return res[KEY] ?? {}
+}
+
+export async function setEntries(data: Record<string, StoredEntry>): Promise<void> {
+  await chrome.storage.local.set({[KEY]: data})
+}
+
+export async function updateEntry(host: string, entry: StoredEntry): Promise<void> {
+  const entries = await getEntries()
+  entries[host] = entry
+  await setEntries(entries)
+}


### PR DESCRIPTION
## Summary
- implement `DomainTree` and `Popup` UI
- add an options page for saving credentials
- implement background message handler
- add storage helpers and crypto utilities with PBKDF2

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ed419af14832c86f258a13bf3a317

## Summary by Sourcery

Add a TypeScript-based Chrome extension for secure password management, including UI components, background message handling, storage helpers, and cryptography utilities.

New Features:
- Implement a background message handler with login, logout, get-credentials, save-credentials, and list commands
- Add a popup UI component for master password authentication and displaying credentials
- Introduce a DomainTree component to group and display stored credentials by base and subdomains
- Add an options page for entering, generating, and saving new credentials
- Provide storage utilities for retrieving and updating encrypted credential entries
- Provide crypto utilities for key derivation, AES-GCM encryption, and decryption

Enhancements:
- Switch key derivation to native PBKDF2 via the Web Crypto API to remove the argon2-browser dependency